### PR TITLE
fix: replace curl with wget

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,5 +19,5 @@ ENV HOSTNAME="0.0.0.0"
 EXPOSE 3000
 
 HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 \
-    CMD curl -f http://localhost:3000/health || exit 1
+    CMD wget --no-verbose --tries=1 --spider http://localhost:3000/ || exit 1 
 CMD ["npm", "start"]


### PR DESCRIPTION
@ejsadiarin 

removed curl in favor of wget and temporarily changed the ping target from health to the root using localhost. container might be crashing due to wrong OS tools (curl not native) or unbuilt endpoints (/health)