### PR TITLE
Feat/additional improvements

### DIFF
--- a/src/app/(applications)/[slug]/loading.tsx
+++ b/src/app/(applications)/[slug]/loading.tsx
@@ -1,0 +1,28 @@
+import { Skeleton } from '@/components/atoms/Skeleton';
+
+export default function AppDetailLoading() {
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+        {/* Header */}
+        <Skeleton className="h-8 w-2/3 mb-4" />
+        <Skeleton className="h-5 w-1/3 mb-8" />
+
+        {/* Image */}
+        <Skeleton className="w-full h-64 rounded-xl mb-8" />
+
+        {/* Description */}
+        <Skeleton className="h-4 w-full mb-2" />
+        <Skeleton className="h-4 w-5/6 mb-2" />
+        <Skeleton className="h-4 w-4/6 mb-8" />
+
+        {/* Tags */}
+        <div className="flex gap-2 mb-8">
+          <Skeleton className="h-6 w-16 rounded-full" />
+          <Skeleton className="h-6 w-20 rounded-full" />
+          <Skeleton className="h-6 w-14 rounded-full" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { useEffect } from 'react';
+
+interface ErrorProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+export default function Error({ error, reset }: ErrorProps) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="min-h-[70vh] flex flex-col items-center justify-center bg-gray-50 p-8">
+      <div className="text-center">
+        <h1 className="text-6xl font-extrabold text-red-500 mb-2">Error</h1>
+        <h2 className="text-3xl font-semibold text-gray-900 mb-4">Something went wrong</h2>
+        <p className="text-gray-600 mb-8">
+          An unexpected error occurred. Please try again.
+        </p>
+        <button
+          onClick={reset}
+          className="px-6 py-3 bg-green-600 text-white font-medium rounded-lg hover:bg-green-700 transition-colors"
+        >
+          Try again
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,0 +1,15 @@
+import { AppCardSkeleton } from '@/components/molecules/AppCardSkeleton';
+
+export default function Loading() {
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {Array.from({ length: 9 }).map((_, i) => (
+            <AppCardSkeleton key={i} />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,21 @@
+import Link from 'next/link';
+
+export default function NotFound() {
+  return (
+    <div className="min-h-[70vh] flex flex-col items-center justify-center bg-gray-50 p-8">
+      <div className="text-center">
+        <h1 className="text-6xl font-extrabold text-green-600 mb-2">404</h1>
+        <h2 className="text-3xl font-semibold text-gray-900 mb-4">Page Not Found</h2>
+        <p className="text-gray-600 mb-8">
+          The page you&apos;re looking for doesn&apos;t exist or has been moved.
+        </p>
+        <Link
+          href="/"
+          className="px-6 py-3 bg-green-600 text-white font-medium rounded-lg hover:bg-green-700 transition-colors"
+        >
+          Go to App Directory
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/components/atoms/Skeleton.tsx
+++ b/src/components/atoms/Skeleton.tsx
@@ -1,0 +1,7 @@
+interface SkeletonProps {
+  className?: string;
+}
+
+export function Skeleton({ className = '' }: SkeletonProps) {
+  return <div className={`animate-pulse bg-gray-200 rounded ${className}`} />;
+}

--- a/src/components/molecules/AppCardSkeleton.tsx
+++ b/src/components/molecules/AppCardSkeleton.tsx
@@ -1,0 +1,28 @@
+import { Skeleton } from '@/components/atoms/Skeleton';
+
+export function AppCardSkeleton() {
+  return (
+    <div className="bg-white border border-gray-200 rounded-lg shadow-sm p-3 flex flex-col">
+      {/* Image */}
+      <Skeleton className="w-full h-45 mb-4 rounded-xl" />
+
+      {/* Title row */}
+      <div className="flex items-center justify-between mb-2">
+        <Skeleton className="h-5 w-2/3" />
+        <Skeleton className="h-4 w-8" />
+      </div>
+
+      {/* Description */}
+      <Skeleton className="h-4 w-full mb-2" />
+      <Skeleton className="h-4 w-5/6 mb-2" />
+      <Skeleton className="h-4 w-4/6 mb-4" />
+
+      {/* Tags */}
+      <div className="flex gap-2">
+        <Skeleton className="h-5 w-12 rounded-full" />
+        <Skeleton className="h-5 w-16 rounded-full" />
+        <Skeleton className="h-5 w-10 rounded-full" />
+      </div>
+    </div>
+  );
+}

--- a/src/components/molecules/Pagination.tsx
+++ b/src/components/molecules/Pagination.tsx
@@ -1,0 +1,33 @@
+interface PaginationProps {
+  page: number;
+  totalPages: number;
+  onPageChange: (page: number) => void;
+}
+
+export function Pagination({ page, totalPages, onPageChange }: PaginationProps) {
+  if (totalPages <= 1) return null;
+
+  return (
+    <div className="flex items-center justify-center gap-4 mt-8">
+      <button
+        onClick={() => onPageChange(page - 1)}
+        disabled={page <= 1}
+        className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 disabled:opacity-40 disabled:cursor-not-allowed"
+      >
+        Previous
+      </button>
+
+      <span className="text-sm text-gray-600">
+        Page {page} of {totalPages}
+      </span>
+
+      <button
+        onClick={() => onPageChange(page + 1)}
+        disabled={page >= totalPages}
+        className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 disabled:opacity-40 disabled:cursor-not-allowed"
+      >
+        Next
+      </button>
+    </div>
+  );
+}

--- a/src/features/apps/containers/AppDetailContainer.tsx
+++ b/src/features/apps/containers/AppDetailContainer.tsx
@@ -7,8 +7,7 @@ import { AppDetail } from '../components/AppDetail';
 import { RatingsContainer } from '@/features/ratings/containers/RatingsContainer';
 import { useFavoriteToggle } from '@/features/favorites/hooks/useFavoriteToggle';
 import { useApplicationRatingsQuery } from '@/features/ratings/queries/ratings.queries';
-import { Button } from '@/components/atoms/Button';
-import Link from 'next/link';
+import { notFound } from 'next/navigation';
 
 export interface AppDetailContainerProps {
   slug: string;
@@ -29,23 +28,13 @@ export function AppDetailContainer({ slug }: AppDetailContainerProps) {
   }
 
   if (isError || !app) {
-    return (
-      <div className="min-h-[70vh] flex flex-col items-center justify-center bg-gray-50 p-8">
-        <div className="text-center">
-          <h1 className="text-6xl font-extrabold text-blue-600 mb-2">404</h1>
-          <h2 className="text-3xl font-semibold text-gray-900 mb-4">App Not Found</h2>
-          <p className="text-gray-600 mb-8">
-            The app with the slug &quot;{slug}&quot; could not be found.
-          </p>
-          <Link href="/">
-            <Button variant="primary">Go to App Directory</Button>
-          </Link>
-        </div>
-      </div>
-    );
+    notFound();
   }
 
+  
+
   return (
+    
     <AppDetail
       app={app}
       favoritesCount={favoritesData?.count}

--- a/src/features/apps/containers/AppDetailContainer.tsx
+++ b/src/features/apps/containers/AppDetailContainer.tsx
@@ -8,6 +8,7 @@ import { RatingsContainer } from '@/features/ratings/containers/RatingsContainer
 import { useFavoriteToggle } from '@/features/favorites/hooks/useFavoriteToggle';
 import { useApplicationRatingsQuery } from '@/features/ratings/queries/ratings.queries';
 import { notFound } from 'next/navigation';
+import { Skeleton } from '@/components/atoms/Skeleton';
 
 export interface AppDetailContainerProps {
   slug: string;
@@ -21,8 +22,20 @@ export function AppDetailContainer({ slug }: AppDetailContainerProps) {
 
   if (isLoading) {
     return (
-      <div className="min-h-[70vh] flex items-center justify-center bg-gray-50">
-        <p className="text-gray-500">Loading...</p>
+      <div className="min-h-screen bg-gray-50">
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+          <Skeleton className="h-8 w-2/3 mb-4" />
+          <Skeleton className="h-5 w-1/3 mb-8" />
+          <Skeleton className="w-full h-64 rounded-xl mb-8" />
+          <Skeleton className="h-4 w-full mb-2" />
+          <Skeleton className="h-4 w-5/6 mb-2" />
+          <Skeleton className="h-4 w-4/6 mb-8" />
+          <div className="flex gap-2">
+            <Skeleton className="h-6 w-16 rounded-full" />
+            <Skeleton className="h-6 w-20 rounded-full" />
+            <Skeleton className="h-6 w-14 rounded-full" />
+          </div>
+        </div>
       </div>
     );
   }

--- a/src/features/apps/containers/AppsContainer.tsx
+++ b/src/features/apps/containers/AppsContainer.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/atoms/Button';
 import { AppCard } from '../components/AppCard';
 import { useAppsContainer } from '@/features/apps/hooks/useAppsContainer';
 import { Pagination } from '@/components/molecules/Pagination';
+import { AppCardSkeleton } from '@/components/molecules/AppCardSkeleton';
 
 export default function AppsContainer() {
   const [hasMounted, setHasMounted] = useState(false);
@@ -100,7 +101,11 @@ export default function AppsContainer() {
       {/* Apps Grid */}
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         {isLoading ? (
-          <div className="text-center py-12 text-gray-500">Loading apps...</div>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            {Array.from({ length: 9 }).map((_, i) => (
+              <AppCardSkeleton key={i} />
+            ))}
+          </div>
         ) : isError ? (
           <div className="text-center py-12 text-red-500">
             Unable to load apps right now. Please try again later.

--- a/src/features/apps/containers/AppsContainer.tsx
+++ b/src/features/apps/containers/AppsContainer.tsx
@@ -6,12 +6,16 @@ import { FilterButton } from '@/components/molecules/FilterButton';
 import { Button } from '@/components/atoms/Button';
 import { AppCard } from '../components/AppCard';
 import { useAppsContainer } from '@/features/apps/hooks/useAppsContainer';
+import { Pagination } from '@/components/molecules/Pagination';
 
 export default function AppsContainer() {
   const [hasMounted, setHasMounted] = useState(false);
 
   const {
     apps,
+    meta,
+    page,
+    setPage,
     filters,
     uniqueTags,
     handleSearchChange,
@@ -134,6 +138,14 @@ export default function AppsContainer() {
               Clear all filters
             </Button>
           </div>
+        )}
+
+        {meta && (
+          <Pagination
+            page={page}
+            totalPages={meta.totalPages}
+            onPageChange={setPage}
+          />
         )}
       </div>
     </div>

--- a/src/features/apps/containers/ProfileContainer.tsx
+++ b/src/features/apps/containers/ProfileContainer.tsx
@@ -14,6 +14,7 @@ import { useApplicationsQuery, useUpdateApplicationMutation, useDeleteApplicatio
 import { useUIStore } from '@/store/uiStore';
 import { Application } from '../types/app.types';
 import { useMemo, useEffect, useCallback } from 'react';
+import { FavoritesContainer } from '@/features/favorites/containers/FavoritesContainer';
 
 interface ProfileContainerProps {
   slug: string;
@@ -206,10 +207,8 @@ export default function ProfileContainer({ slug: _slug }: ProfileContainerProps)
             </div>
           )}
 
-          {activeTab === 'favorites' && (
-            <div className="text-center py-12 text-gray-500">
-              No favorite apps selected.
-            </div>
+          {activeTab === 'favorites' && session?.user?.id && (
+            <FavoritesContainer userId={session.user.id} />
           )}
         </div>
       </div>

--- a/src/features/apps/hooks/useAppsContainer.ts
+++ b/src/features/apps/hooks/useAppsContainer.ts
@@ -9,15 +9,17 @@ export function useAppsContainer() {
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
   const [debouncedSearch, setDebouncedSearch] = useState('');
+  const [page, setPage] = useState(1);
 
   useEffect(() => {
     const timer = setTimeout(() => setDebouncedSearch(searchQuery), 300);
     return () => clearTimeout(timer);
   }, [searchQuery]);
 
-  const query = useApplicationsQuery({ searchQuery: debouncedSearch, selectedTags });
+   const query = useApplicationsQuery({ searchQuery: debouncedSearch, selectedTags }, { page });
 
   const apps = useMemo(() => query.data?.data ?? [], [query.data]);
+  const meta = query.data?.meta;
 
   const uniqueTags = useMemo(() => {
     const tags = new Set<string>();
@@ -31,17 +33,20 @@ export function useAppsContainer() {
 
   const handleSearchChange = useCallback((value: string) => {
     setSearchQuery(value);
+    setPage(1);
   }, []);
 
   const toggleTag = useCallback((tag: string) => {
     setSelectedTags((prev) =>
       prev.includes(tag) ? prev.filter((t) => t !== tag) : [...prev, tag],
     );
+    setPage(1);
   }, []);
 
   const clearFilters = useCallback(() => {
     setSearchQuery('');
     setSelectedTags([]);
+    setPage(1);
   }, []);
 
   const handleAppClick = useCallback((app: Application) => {
@@ -50,6 +55,9 @@ export function useAppsContainer() {
 
   return {
     apps,
+    meta,
+    page,
+    setPage,
     filters: { searchQuery, selectedTags },
     uniqueTags,
     handleSearchChange,

--- a/src/features/apps/queries/apps.queries.ts
+++ b/src/features/apps/queries/apps.queries.ts
@@ -15,14 +15,18 @@ export const applicationsQueryKey = (filters: Partial<AppFilters>) => [
   filters.selectedTags ?? [],
 ];
 
-export function useApplicationsQuery(filters: Partial<AppFilters> = {}, options?: { enabled?: boolean }) {
+export function useApplicationsQuery(filters: Partial<AppFilters> = {}, options?: { enabled?: boolean; page?: number; limit?: number }) {
+  const page = options?.page ?? 1;
+  const limit = options?.limit;
   return useQuery({
-    queryKey: applicationsQueryKey(filters),
+    queryKey: [...applicationsQueryKey(filters), page, limit],
     queryFn: () =>
       getApplications({
         search: filters.searchQuery || undefined,
         tags: filters.selectedTags && filters.selectedTags.length > 0 ? filters.selectedTags : undefined,
         userId: filters.userId || undefined,
+        page,
+        limit,
       }),
     retry: 1,
     enabled: options?.enabled ?? true,

--- a/src/features/favorites/containers/FavoritesContainer.tsx
+++ b/src/features/favorites/containers/FavoritesContainer.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { useUserFavoritesQuery } from '../queries/favorites.queries';
+import { useApplicationsQuery } from '@/features/apps/queries/apps.queries';
+import { AppCard } from '@/features/apps/components/AppCard';
+
+interface FavoritesContainerProps {
+  userId: string;
+}
+
+export function FavoritesContainer({ userId }: FavoritesContainerProps) {
+  const { data: favoritesData, isLoading: favLoading } = useUserFavoritesQuery(userId);
+  const { data: appsData, isLoading: appsLoading } = useApplicationsQuery();
+
+  const isLoading = favLoading || appsLoading;
+
+  const favoriteApps = (appsData?.data ?? []).filter((app) =>
+    (favoritesData?.applicationIds ?? []).includes(app.id),
+  );
+
+  if (isLoading) {
+    return <div className="text-center py-12 text-gray-500">Loading favorites...</div>;
+  }
+
+  if (favoriteApps.length === 0) {
+    return (
+      <div className="text-center py-12 text-gray-500">
+        No favorite apps yet. Browse apps and click the bookmark to save them here.
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+      {favoriteApps.map((app) => (
+        <AppCard key={app.id} app={app} />
+      ))}
+    </div>
+  );
+}

--- a/src/features/ratings/containers/RatingsContainer.tsx
+++ b/src/features/ratings/containers/RatingsContainer.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { authClient } from '@/lib/auth-client';
 import { Button } from '@/components/atoms/Button';
 import { RatingForm } from '../components/RatingForm';
@@ -27,27 +27,68 @@ export function RatingsContainer({ slug }: RatingsContainerProps) {
   const deleteMutation = useDeleteRatingMutation(slug);
 
   const [isEditing, setIsEditing] = useState(false);
+  const [anonCache, setAnonCache] = useState<Pick<CreateRatingPayload, 'score' | 'comment' | 'isAnonymous'> | null>(null);
+
+  const anonKey = `anon-rated-${slug}`;
+
+  useEffect(() => {
+    const stored = localStorage.getItem(anonKey);
+    if (stored) setAnonCache(JSON.parse(stored));
+  }, [anonKey]);
 
   const currentUserEmail = session?.user?.email;
-  const userRating = ratingsData?.ratings.find(
+  const emailRating = ratingsData?.ratings.find(
     (r) => r.userEmail !== null && r.userEmail === currentUserEmail,
   );
+  const userRating = emailRating ?? (anonCache
+    ? { score: anonCache.score, comment: anonCache.comment ?? null, isAnonymous: true, userEmail: null, applicationId: ratingsData?.ratings[0]?.applicationId ?? 0 }
+    : undefined);
 
   const handleCreate = (payload: CreateRatingPayload) => {
-    createMutation.mutate(payload);
+    createMutation.mutate(payload, {
+      onSuccess: () => {
+        if (payload.isAnonymous) {
+          const cached = { score: payload.score, comment: payload.comment ?? null, isAnonymous: true };
+          localStorage.setItem(anonKey, JSON.stringify(cached));
+          setAnonCache(cached);
+        }
+      },
+    });
   };
 
   const handlePatch = (payload: CreateRatingPayload) => {
-    patchMutation.mutate(payload, { onSuccess: () => setIsEditing(false) });
+    patchMutation.mutate(payload, {
+      onSuccess: () => {
+        setIsEditing(false);
+        if (payload.isAnonymous) {
+          const cached = { score: payload.score, comment: payload.comment ?? null, isAnonymous: true };
+          localStorage.setItem(anonKey, JSON.stringify(cached));
+          setAnonCache(cached);
+        } else {
+          localStorage.removeItem(anonKey);
+          setAnonCache(null);
+        }
+      },
+    });
   };
 
   const handleDelete = () => {
-    deleteMutation.mutate();
+    deleteMutation.mutate(undefined, {
+      onSuccess: () => {
+        localStorage.removeItem(anonKey);
+        setAnonCache(null);
+      },
+    });
   };
 
-  const otherRatings = ratingsData?.ratings.filter(
-    (r) => r.userEmail !== currentUserEmail,
-  ) ?? [];
+  const anonRatingIndex = (!emailRating && anonCache)
+    ? (ratingsData?.ratings.findIndex((r) => r.isAnonymous && r.userEmail === null) ?? -1)
+    : -1;
+
+  const otherRatings = (ratingsData?.ratings ?? []).filter((r, i) => {
+    if (i === anonRatingIndex) return false;
+    return r.userEmail !== currentUserEmail;
+  });
 
   return (
     <div className="lg:col-span-1 lg:border-l border-gray-200 lg:pl-8">


### PR DESCRIPTION
# feat(web): add pagination, favorites tab, error pages, skeletons, and anonymous rating fix

## Summary

Five frontend-only improvements to `lasallian-me-web`:

1. **Profile Favorites Tab**: wired the existing Favorites tab on the profile page using the already-built `useUserFavoritesQuery` hook; renders a grid of `AppCard` components for the user's favorited apps.
2. **Pagination UI**: added a `Pagination` component to the apps listing; reads `meta.totalPages` from the API response (which already supported pagination) and resets to page 1 on search/filter changes.
3. **Error & Not-Found Pages**: added `app/not-found.tsx` (global 404) and `app/error.tsx` (error boundary with retry button); `AppDetailContainer` now calls `notFound()` instead of rendering inline error UI.
4. **Loading Skeleton States**: added `Skeleton` and `AppCardSkeleton` components; integrated directly into `AppsContainer` and `AppDetailContainer` so skeletons show during TanStack Query fetches; also added route-level `loading.tsx` files for JS parse time on slower devices.
5. **Anonymous Rating Fix**: after submitting an anonymous review, stores the rating in `localStorage` keyed by `anon-rated-${slug}` so Edit/Delete controls persist across page reloads. Also fixed a double-render bug where the anonymous rating appeared in both "Your Review" and the general reviews list.

## Linked Issues

closes #N/A

## Type of Change

- [x] feat: New feature
- [ ] fix: Bug fix
- [ ] docs: Documentation update
- [ ] chore/refactor: Maintenance or code restructure

## Notes for Reviewers

- **Pagination** is only visible once there are more than 10 approved apps in the database (the API's default `DEFAULT_LIMIT`).
- **Anonymous rating localStorage** is scoped per app slug (`anon-rated-${slug}`) and is cleared on edit (if switching to non-anonymous) or delete.
- The **Reviews tab** on the profile page remains a placeholder. It requires a new backend endpoint (`GET /api/ratings/users/:userId`) which is out of scope for this PR.