### PR TITLE
feat(ratings): display Google display name instead of email in reviews

### DIFF
--- a/src/features/ratings/components/ReviewItem.tsx
+++ b/src/features/ratings/components/ReviewItem.tsx
@@ -7,7 +7,9 @@ interface ReviewItemProps {
 }
 
 export function ReviewItem({ rating }: ReviewItemProps) {
-  const displayName = rating.isAnonymous || !rating.userEmail ? 'Anonymous' : rating.userEmail;
+  const displayName = rating.isAnonymous || (!rating.userName && !rating.userEmail)
+    ? 'Anonymous'
+    : (rating.userName ?? rating.userEmail!);
 
   return (
     <div className="py-4 first:pt-0 last:pb-0">

--- a/src/features/ratings/types/rating.types.ts
+++ b/src/features/ratings/types/rating.types.ts
@@ -4,6 +4,7 @@ export interface Rating {
   comment: string | null;
   isAnonymous: boolean;
   userEmail: string | null;
+  userName: string | null;
 }
 
 export interface ApplicationRatings {


### PR DESCRIPTION
## Summary

- Adds `userName: string | null` to the `Rating` type to match the updated API response
- Updates `ReviewItem` to show `userName` as the primary display identifier, falling back to `userEmail` if `userName` is absent
- Anonymous reviews continue to show `"Anonymous"`
- Avatar initial now uses the first letter of `userName` when available

## Files changed

| File | Change |
|------|--------|
| `src/features/ratings/types/rating.types.ts` | Added `userName: string | null` to `Rating` interface |
| `src/features/ratings/components/ReviewItem.tsx` | `displayName` now prefers `userName` over `userEmail` |

## Test plan
- [ ] Reviews on an app detail page show the reviewer's Google display name
- [ ] Anonymous reviews still show `"Anonymous"`
- [ ] Avatar initial reflects the display name

Closes #50
Depends on: dlsu-lscs/lasallian-me-api#37

---
_Generated by [Claude Code](https://claude.ai/code/session_013hCrU1CLziMDPNKLfVkj1Q)_