### PR TITLE
feat(applications): add author field to submit form and display

### DIFF
--- a/src/features/admin/components/EditModal.tsx
+++ b/src/features/admin/components/EditModal.tsx
@@ -17,6 +17,7 @@ export function EditModal({ isOpen, onClose, application, onSave, isSubmitting }
   const [slug, setSlug] = useState('');
   const [description, setDescription] = useState('');
   const [url, setUrl] = useState('');
+  const [author, setAuthor] = useState('');
   const [tags, setTags] = useState('');
 
   useEffect(() => {
@@ -25,6 +26,7 @@ export function EditModal({ isOpen, onClose, application, onSave, isSubmitting }
       setSlug(application.slug ?? '');
       setDescription(application.description ?? '');
       setUrl(application.url ?? '');
+      setAuthor(application.author ?? '');
       setTags(application.tags?.join(', ') ?? '');
     }
   }, [application]);
@@ -36,6 +38,7 @@ export function EditModal({ isOpen, onClose, application, onSave, isSubmitting }
       slug: slug.trim() || undefined,
       description: description.trim() || undefined,
       url: url.trim() || undefined,
+      author: author.trim() || undefined,
       tags: tags
         ? tags.split(',').map((t) => t.trim()).filter(Boolean)
         : undefined,
@@ -68,6 +71,12 @@ export function EditModal({ isOpen, onClose, application, onSave, isSubmitting }
           label="URL"
           value={url}
           onChange={(e) => setUrl(e.target.value)}
+        />
+        <Input
+          label="Author"
+          value={author}
+          onChange={(e) => setAuthor(e.target.value)}
+          placeholder="e.g. Jane Doe or LSCS Dev Team"
         />
         <Input
           label="Tags (comma-separated)"

--- a/src/features/apps/components/AppCard.tsx
+++ b/src/features/apps/components/AppCard.tsx
@@ -119,6 +119,9 @@ export function AppCard({ app, showTags = true, className }: AppCardProps) {
               )}
             </span>
           </div>
+          {app.author && (
+            <p className="text-white/40 text-xs truncate">{app.author}</p>
+          )}
           <p className="text-white/60 text-sm font-semibold leading-relaxed truncate">
             {app.description}
           </p>

--- a/src/features/apps/components/AppDetail.tsx
+++ b/src/features/apps/components/AppDetail.tsx
@@ -61,9 +61,11 @@ export function AppDetail({
               </button>
             </div>
 
-            <p className="text-white/45 text-sm">
-              By <span className="text-white/65 font-semibold">{app.userEmail?.split('@')[0] ?? 'Unknown'}</span>
-            </p>
+            {(app.author || app.userEmail) && (
+              <p className="text-white/45 text-sm">
+                By <span className="text-white/65 font-semibold">{app.author ?? app.userEmail?.split('@')[0]}</span>
+              </p>
+            )}
 
             {/* Stats row */}
             <div className="flex items-center gap-4 flex-wrap">

--- a/src/features/apps/types/app.types.ts
+++ b/src/features/apps/types/app.types.ts
@@ -9,6 +9,7 @@ export interface Application {
   tags: string[] | null;
   userId: string;
   userEmail?: string;
+  author?: string | null;
   isApproved: 'PENDING' | 'APPROVED' | 'REJECTED' | 'REMOVED';
   rejectionReason?: string | null;
   createdAt: string;

--- a/src/features/submit/components/SubmitForm.tsx
+++ b/src/features/submit/components/SubmitForm.tsx
@@ -33,6 +33,7 @@ export function SubmitForm({ onSubmit, isSubmitting, submitLabel, error, isSucce
   const [slugEdited, setSlugEdited] = useState(false);
   const [description, setDescription] = useState('');
   const [url, setUrl] = useState('');
+  const [author, setAuthor] = useState('');
   const [githubLink, setGithubLink] = useState('');
   const [tags, setTags] = useState('');
   const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
@@ -78,6 +79,7 @@ export function SubmitForm({ onSubmit, isSubmitting, submitLabel, error, isSucce
         githubLink: githubLink.trim(),
         description: description.trim() || undefined,
         url: url.trim() || undefined,
+        author: author.trim() || undefined,
         tags: tags ? tags.split(',').map((t) => t.trim()).filter(Boolean) : undefined,
       },
       selectedFiles,
@@ -143,6 +145,13 @@ export function SubmitForm({ onSubmit, isSubmitting, submitLabel, error, isSucce
         value={url}
         onChange={(e) => setUrl(e.target.value)}
         placeholder="https://myapp.example.com"
+      />
+
+      <Input
+        label="Author"
+        value={author}
+        onChange={(e) => setAuthor(e.target.value)}
+        placeholder="e.g. Jane Doe or LSCS Dev Team"
       />
 
       <Input

--- a/src/features/submit/types/submit.types.ts
+++ b/src/features/submit/types/submit.types.ts
@@ -4,6 +4,7 @@ export interface SubmitApplicationForm {
   githubLink: string;
   description?: string;
   url?: string;
+  author?: string;
   tags?: string[];
   previewImages?: string[];
 }


### PR DESCRIPTION
## Summary

- Adds `author?: string | null` to the `Application` type and `author?: string` to `SubmitApplicationForm`
- New optional **Author** text input in the submit form (between App URL and GitHub Link)
- `AppDetail` "By" line now prefers `author` over the `userEmail` username fallback
- `AppCard` shows `author` as a small subtitle below the app title when present
- Admin `EditModal` gains an editable Author field

## Files changed

| File | Change |
|------|--------|
| `src/features/apps/types/app.types.ts` | Added `author?: string \| null` |
| `src/features/submit/types/submit.types.ts` | Added `author?: string` |
| `src/features/submit/components/SubmitForm.tsx` | Added Author input, wired into submit payload |
| `src/features/apps/components/AppDetail.tsx` | "By" line uses `author` with `userEmail` fallback |
| `src/features/apps/components/AppCard.tsx` | Shows `author` as a small muted subtitle when set |
| `src/features/admin/components/EditModal.tsx` | Added Author field with state and save wiring |

## Test plan
- [ ] Submit form shows an optional Author field
- [ ] Submitting without author works
- [ ] Submitting with author stores and displays it correctly
- [ ] `AppDetail` shows the author name in the "By" line
- [ ] `AppCard` shows author below the title when set
- [ ] Admin edit modal can read and update the author field

Closes #47
Depends on: dlsu-lscs/lasallian-me-api#35

---
_Generated by [Claude Code](https://claude.ai/code/session_013hCrU1CLziMDPNKLfVkj1Q)_