### PR TITLE
feat(submit): require app url, make github url optional

### DIFF
--- a/src/features/apps/types/app.types.ts
+++ b/src/features/apps/types/app.types.ts
@@ -3,8 +3,8 @@ export interface Application {
   title: string;
   slug: string;
   description: string | null;
-  url: string | null;
-  githubLink: string;
+  url: string;
+  githubLink: string | null;
   previewImages: string[] | null;
   tags: string[] | null;
   userId: string;

--- a/src/features/submit/components/SubmitForm.tsx
+++ b/src/features/submit/components/SubmitForm.tsx
@@ -76,10 +76,10 @@ export function SubmitForm({ onSubmit, isSubmitting, submitLabel, error, isSucce
       {
         title: title.trim(),
         slug: slug.trim(),
-        githubLink: githubLink.trim(),
+        url: url.trim(),
         description: description.trim() || undefined,
-        url: url.trim() || undefined,
         author: author.trim() || undefined,
+        githubLink: githubLink.trim() || undefined,
         tags: tags ? tags.split(',').map((t) => t.trim()).filter(Boolean) : undefined,
       },
       selectedFiles,
@@ -140,11 +140,12 @@ export function SubmitForm({ onSubmit, isSubmitting, submitLabel, error, isSucce
       </div>
 
       <Input
-        label="App URL"
+        label="App URL *"
         type="url"
         value={url}
         onChange={(e) => setUrl(e.target.value)}
         placeholder="https://myapp.example.com"
+        required
       />
 
       <Input
@@ -155,12 +156,11 @@ export function SubmitForm({ onSubmit, isSubmitting, submitLabel, error, isSucce
       />
 
       <Input
-        label="GitHub Link *"
+        label="GitHub Link"
         type="url"
         value={githubLink}
         onChange={(e) => setGithubLink(e.target.value)}
         placeholder="https://github.com/user/repo"
-        required
       />
 
       <Input
@@ -231,7 +231,7 @@ export function SubmitForm({ onSubmit, isSubmitting, submitLabel, error, isSucce
 
       <button
         type="submit"
-        disabled={isSubmitting || !title.trim() || !slug.trim() || !githubLink.trim()}
+        disabled={isSubmitting || !title.trim() || !slug.trim() || !url.trim()}
         className="w-full py-3 rounded-full text-sm font-semibold bg-white text-black hover:bg-white/80 transition-colors cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed mt-1"
       >
         {submitLabel}

--- a/src/features/submit/types/submit.types.ts
+++ b/src/features/submit/types/submit.types.ts
@@ -1,10 +1,10 @@
 export interface SubmitApplicationForm {
   title: string;
   slug: string;
-  githubLink: string;
+  url: string;
   description?: string;
-  url?: string;
   author?: string;
+  githubLink?: string;
   tags?: string[];
   previewImages?: string[];
 }


### PR DESCRIPTION
## Summary

- **App URL** is now a required field: marked with `*`, has `required` attribute, and gates the submit button
- **GitHub Link** is now optional: asterisk and `required` attribute removed
- `SubmitApplicationForm.url` changed from `url?: string` to `url: string`
- `SubmitApplicationForm.githubLink` changed from `githubLink: string` to `githubLink?: string`
- `Application.url` changed from `string | null` to `string`
- `Application.githubLink` changed from `string` to `string | null`

## Files changed

| File | Change |
|------|--------|
| `src/features/submit/types/submit.types.ts` | `url: string` (required), `githubLink?: string` (optional) |
| `src/features/apps/types/app.types.ts` | `url: string`, `githubLink: string \| null` |
| `src/features/submit/components/SubmitForm.tsx` | Label/required attr swapped; submit guard uses `url` |

## Test plan
- [ ] Submitting the form without an App URL is blocked (button disabled, HTML required)
- [ ] Submitting without a GitHub Link succeeds
- [ ] App URL field shows `*` required indicator
- [ ] GitHub Link field has no `*` indicator

Closes #49
Depends on: dlsu-lscs/lasallian-me-api#40

---
_Generated by [Claude Code](https://claude.ai/code/session_013hCrU1CLziMDPNKLfVkj1Q)_