### PR TITLE
feat: add icon field to applications with S3 upload

### DIFF
--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -6,6 +6,7 @@ const ALLOWED_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
 export async function GET(req: NextRequest) {
   const fileName = req.nextUrl.searchParams.get('fileName');
   const contentType = req.nextUrl.searchParams.get('contentType');
+  const type = req.nextUrl.searchParams.get('type');
 
   if (!fileName || !contentType) {
     return NextResponse.json({ error: 'fileName and contentType are required' }, { status: 400 });
@@ -16,7 +17,8 @@ export async function GET(req: NextRequest) {
   }
 
   const ext = fileName.split('.').pop() ?? 'jpg';
-  const key = `preview-images/${Date.now()}-${Math.random().toString(36).slice(2)}.${ext}`;
+  const prefix = type === 'icon' ? 'icons' : 'preview-images';
+  const key = `${prefix}/${Date.now()}-${Math.random().toString(36).slice(2)}.${ext}`;
 
   const presignedUrl = await getPresignedUploadUrl(key, contentType);
   return NextResponse.json({ presignedUrl, key });

--- a/src/features/admin/components/EditModal.tsx
+++ b/src/features/admin/components/EditModal.tsx
@@ -19,6 +19,7 @@ export function EditModal({ isOpen, onClose, application, onSave, isSubmitting }
   const [url, setUrl] = useState('');
   const [author, setAuthor] = useState('');
   const [tags, setTags] = useState('');
+  const [icon, setIcon] = useState('');
 
   useEffect(() => {
     if (application) {
@@ -28,6 +29,7 @@ export function EditModal({ isOpen, onClose, application, onSave, isSubmitting }
       setUrl(application.url ?? '');
       setAuthor(application.author ?? '');
       setTags(application.tags?.join(', ') ?? '');
+      setIcon(application.icon ?? '');
     }
   }, [application]);
 
@@ -42,6 +44,7 @@ export function EditModal({ isOpen, onClose, application, onSave, isSubmitting }
       tags: tags
         ? tags.split(',').map((t) => t.trim()).filter(Boolean)
         : undefined,
+      icon: icon.trim() || undefined,
     });
   };
 
@@ -83,6 +86,12 @@ export function EditModal({ isOpen, onClose, application, onSave, isSubmitting }
           value={tags}
           onChange={(e) => setTags(e.target.value)}
           placeholder="e.g. productivity, social"
+        />
+        <Input
+          label="Icon URL"
+          value={icon}
+          onChange={(e) => setIcon(e.target.value)}
+          placeholder="/api/image?key=icons/..."
         />
 
         <div className="flex justify-end gap-3 pt-2">

--- a/src/features/apps/components/AppCard.tsx
+++ b/src/features/apps/components/AppCard.tsx
@@ -85,9 +85,9 @@ export function AppCard({ app, showTags = true, className }: AppCardProps) {
       <div className="p-3 flex items-center gap-3">
         {/* App icon */}
         <div className="w-12 h-12 rounded-md overflow-hidden bg-black/50 border border-white/8 shrink-0">
-          {app.previewImages?.[0] ? (
+          {(app.icon ?? app.previewImages?.[0]) ? (
             <img
-              src={imgSrc(app.previewImages[0])}
+              src={imgSrc((app.icon ?? app.previewImages![0])!)}
               alt={app.title}
               className="w-full h-full object-cover"
             />

--- a/src/features/apps/components/AppDetail.tsx
+++ b/src/features/apps/components/AppDetail.tsx
@@ -4,6 +4,7 @@ import { FiBookmark, FiExternalLink } from 'react-icons/fi';
 import { FaBookmark } from 'react-icons/fa';
 import { FaStar } from 'react-icons/fa';
 import { ImageGallery } from './ImageGallery';
+import { imgSrc } from '@/lib/img-src';
 
 export interface AppDetailProps {
   app: Application;
@@ -40,7 +41,14 @@ export function AppDetail({
           {/* Title + author + stats */}
           <div className="flex flex-col gap-2">
             <div className="flex items-start justify-between gap-4 flex-wrap">
-              <h1 className="text-3xl font-extrabold text-white leading-tight">{app.title}</h1>
+              <div className="flex items-center gap-3">
+                {app.icon && (
+                  <div className="w-12 h-12 rounded-xl overflow-hidden bg-black/50 border border-white/10 shrink-0">
+                    <img src={imgSrc(app.icon)} alt={`${app.title} icon`} className="w-full h-full object-cover" />
+                  </div>
+                )}
+                <h1 className="text-3xl font-extrabold text-white leading-tight">{app.title}</h1>
+              </div>
 
               {/* Save button */}
               <button

--- a/src/features/apps/types/app.types.ts
+++ b/src/features/apps/types/app.types.ts
@@ -6,6 +6,7 @@ export interface Application {
   url: string;
   githubLink: string | null;
   previewImages: string[] | null;
+  icon?: string | null;
   tags: string[] | null;
   userId: string;
   userEmail?: string;

--- a/src/features/submit/components/SubmitForm.tsx
+++ b/src/features/submit/components/SubmitForm.tsx
@@ -4,7 +4,7 @@ import { SubmitApplicationForm } from '../types/submit.types';
 import { FiUpload, FiX, FiCheck } from 'react-icons/fi';
 
 interface SubmitFormProps {
-  onSubmit: (data: SubmitApplicationForm, files: File[]) => void;
+  onSubmit: (data: SubmitApplicationForm, files: File[], iconFile?: File) => void;
   isSubmitting: boolean;
   submitLabel: string;
   error: string | null;
@@ -38,8 +38,11 @@ export function SubmitForm({ onSubmit, isSubmitting, submitLabel, error, isSucce
   const [tags, setTags] = useState('');
   const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
   const [previewUrls, setPreviewUrls] = useState<string[]>([]);
+  const [iconFile, setIconFile] = useState<File | null>(null);
+  const [iconPreviewUrl, setIconPreviewUrl] = useState<string | null>(null);
   const [isDragging, setIsDragging] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const iconInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     if (!slugEdited) setSlug(toSlug(title));
@@ -50,6 +53,13 @@ export function SubmitForm({ onSubmit, isSubmitting, submitLabel, error, isSucce
     setPreviewUrls(urls);
     return () => { urls.forEach((u) => URL.revokeObjectURL(u)); };
   }, [selectedFiles]);
+
+  useEffect(() => {
+    if (!iconFile) { setIconPreviewUrl(null); return; }
+    const url = URL.createObjectURL(iconFile);
+    setIconPreviewUrl(url);
+    return () => URL.revokeObjectURL(url);
+  }, [iconFile]);
 
   const addFiles = (incoming: File[]) => {
     setSelectedFiles((prev) => [...prev, ...incoming].slice(0, 5));
@@ -83,6 +93,7 @@ export function SubmitForm({ onSubmit, isSubmitting, submitLabel, error, isSucce
         tags: tags ? tags.split(',').map((t) => t.trim()).filter(Boolean) : undefined,
       },
       selectedFiles,
+      iconFile ?? undefined,
     );
   };
 
@@ -171,8 +182,57 @@ export function SubmitForm({ onSubmit, isSubmitting, submitLabel, error, isSucce
       />
       <FieldHint>Comma-separated list of tags.</FieldHint>
 
-      {/* Image upload */}
+      {/* App Icon upload */}
       <div className="w-full -mt-3">
+        <FieldLabel>App Icon</FieldLabel>
+        <div
+          onClick={() => iconInputRef.current?.click()}
+          className="border-2 border-dashed rounded-xl px-4 py-6 text-center cursor-pointer transition-colors border-white/10 hover:border-white/20 hover:bg-white/3"
+        >
+          <input
+            ref={iconInputRef}
+            type="file"
+            accept="image/jpeg,image/png,image/gif,image/webp"
+            className="hidden"
+            onChange={(e) => {
+              const file = e.target.files?.[0];
+              if (file) setIconFile(file);
+              if (iconInputRef.current) iconInputRef.current.value = '';
+            }}
+          />
+          {iconPreviewUrl ? (
+            <div className="flex items-center justify-center gap-3">
+              <div className="relative group w-16 h-16 shrink-0">
+                <img
+                  src={iconPreviewUrl}
+                  alt="Icon preview"
+                  className="w-16 h-16 object-cover rounded-lg border border-white/10"
+                />
+                <button
+                  type="button"
+                  onClick={(e) => { e.stopPropagation(); setIconFile(null); }}
+                  className="absolute -top-1.5 -right-1.5 w-5 h-5 bg-red-500 hover:bg-red-400 text-white rounded-full flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity cursor-pointer"
+                  aria-label="Remove icon"
+                >
+                  <FiX className="w-3 h-3" strokeWidth={3} />
+                </button>
+              </div>
+              <span className="text-sm text-white/50">{iconFile?.name}</span>
+            </div>
+          ) : (
+            <>
+              <FiUpload className="w-5 h-5 text-white/30 mx-auto mb-2" />
+              <p className="text-sm text-white/40">
+                Drop icon here or <span className="text-white/60 font-semibold">click to browse</span>
+              </p>
+            </>
+          )}
+        </div>
+        <FieldHint>A square image representing your app (JPEG, PNG, WebP — max 5 MB).</FieldHint>
+      </div>
+
+      {/* Preview Images upload */}
+      <div className="w-full">
         <FieldLabel>Preview Images</FieldLabel>
         <div
           onDragOver={(e) => { e.preventDefault(); setIsDragging(true); }}

--- a/src/features/submit/containers/SubmitContainer.tsx
+++ b/src/features/submit/containers/SubmitContainer.tsx
@@ -5,7 +5,7 @@ import { useRouter } from 'next/navigation';
 import { authClient } from '@/lib/auth-client';
 import { SubmitForm } from '../components/SubmitForm';
 import { useSubmitApplicationMutation } from '../queries/submit.queries';
-import { uploadImages } from '../services/upload.service';
+import { uploadImages, uploadIcon } from '../services/upload.service';
 import type { SubmitApplicationForm } from '../types/submit.types';
 
 export function SubmitContainer() {
@@ -35,10 +35,11 @@ export function SubmitContainer() {
     return null;
   }
 
-  const handleSubmit = async (formData: SubmitApplicationForm, files: File[]) => {
+  const handleSubmit = async (formData: SubmitApplicationForm, files: File[], iconFile?: File) => {
     setUploadError(null);
 
     let previewImages: string[] | undefined;
+    let icon: string | undefined;
 
     if (files.length > 0) {
       setIsUploading(true);
@@ -55,12 +56,25 @@ export function SubmitContainer() {
       setIsUploading(false);
     }
 
-    mutation.mutate({ ...formData, previewImages });
+    if (iconFile) {
+      setIsUploading(true);
+      try {
+        const uploaded = await uploadIcon(iconFile);
+        icon = `${window.location.origin}/api/image?key=${encodeURIComponent(uploaded.key)}`;
+      } catch (err) {
+        setUploadError(err instanceof Error ? err.message : 'Icon upload failed.');
+        setIsUploading(false);
+        return;
+      }
+      setIsUploading(false);
+    }
+
+    mutation.mutate({ ...formData, previewImages, icon });
   };
 
   const isSubmitting = isUploading || mutation.isPending;
   const submitLabel = isUploading
-    ? 'Uploading images…'
+    ? 'Uploading…'
     : mutation.isPending
       ? 'Submitting…'
       : 'Submit for Review';

--- a/src/features/submit/services/upload.service.ts
+++ b/src/features/submit/services/upload.service.ts
@@ -31,3 +31,27 @@ export async function uploadImages(files: File[]): Promise<UploadResult[]> {
 
   return results;
 }
+
+export async function uploadIcon(file: File): Promise<UploadResult> {
+  const params = new URLSearchParams({ fileName: file.name, contentType: file.type, type: 'icon' });
+  const presignResponse = await fetch(`/api/upload?${params}`);
+
+  if (!presignResponse.ok) {
+    const err = await presignResponse.json().catch(() => ({}));
+    throw new Error(err?.error ?? 'Failed to get upload URL. Please try again.');
+  }
+
+  const { presignedUrl, key } = await presignResponse.json();
+
+  const uploadResponse = await fetch(presignedUrl, {
+    method: 'PUT',
+    headers: { 'Content-Type': file.type },
+    body: file,
+  });
+
+  if (!uploadResponse.ok) {
+    throw new Error('Failed to upload icon. Please try again.');
+  }
+
+  return { key };
+}

--- a/src/features/submit/types/submit.types.ts
+++ b/src/features/submit/types/submit.types.ts
@@ -7,4 +7,5 @@ export interface SubmitApplicationForm {
   githubLink?: string;
   tags?: string[];
   previewImages?: string[];
+  icon?: string;
 }


### PR DESCRIPTION
## Summary

Closes #44

- Upload route: `?type=icon` query param switches S3 key prefix to `icons/`
- Upload service: new `uploadIcon(file)` function
- `Application` type and `SubmitApplicationForm` type get `icon` field
- Submit form: single-file icon picker with square preview thumbnail (reuses existing drag-drop pattern)
- Submit container: uploads icon before mutation, includes `icon` URL in payload
- `AppCard`: icon area (`w-12 h-12`) uses `app.icon` first, falls back to `previewImages[0]`
- `AppDetail`: shows icon beside the app title in the header
- `EditModal`: adds an Icon URL text input for admin corrections

## Test plan

- [ ] Submit form shows "App Icon" picker; selecting a file shows square preview
- [ ] Submitting without an icon works (field is optional)
- [ ] On submit, icon is uploaded to S3 under the `icons/` prefix
- [ ] `AppCard` shows the icon in the small icon slot; falls back to `previewImages[0]` if no icon
- [ ] `AppDetail` shows the icon beside the title when present; title-only layout unchanged when absent
- [ ] Admin edit modal pre-populates the Icon URL field and saves changes
- [ ] Non-image files are rejected by the upload route (400)

## Related

- API PR: dlsu-lscs/lasallian-me-api (same branch `claude/fix-api-web-issues-znAlB`)

---
_Generated by [Claude Code](https://claude.ai/code/session_017mJAdrApQkjh22MtRs4cFA)_