### PR TITLE
fix: photo fetching and presigned upload type param

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -6,6 +6,15 @@ if (!process.env.NEXT_PUBLIC_SITE_URL) {
 
 const nextConfig: NextConfig = {
   images: {
+    localPatterns: [
+      {
+        pathname: '/api/signed',
+        search: '**',
+      },
+      {
+        pathname: '/**',
+      },
+    ],
     remotePatterns: [
       {
         protocol: 'https',

--- a/src/app/api/signed/route.ts
+++ b/src/app/api/signed/route.ts
@@ -1,0 +1,35 @@
+import { S3Client, GetObjectCommand } from '@aws-sdk/client-s3';
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import { NextRequest, NextResponse } from 'next/server';
+
+const s3 = new S3Client({
+  region: process.env.S3_REGION!,
+  endpoint: process.env.S3_ENDPOINT!,
+  credentials: {
+    accessKeyId: process.env.S3_ACCESS_KEY_ID!,
+    secretAccessKey: process.env.S3_SECRET_ACCESS_KEY!,
+  },
+  forcePathStyle: true,
+});
+
+const ALLOWED_PREFIXES = ['preview-images/', 'icons/'];
+
+export async function GET(req: NextRequest) {
+  const key = req.nextUrl.searchParams.get('key');
+
+  if (!key || !ALLOWED_PREFIXES.some((p) => key.startsWith(p))) {
+    return NextResponse.json({ error: 'Invalid key' }, { status: 400 });
+  }
+
+  const command = new GetObjectCommand({
+    Bucket: process.env.S3_BUCKET!,
+    Key: key,
+  });
+
+  const signedUrl = await getSignedUrl(s3, command, { expiresIn: 3600 });
+
+  return NextResponse.redirect(signedUrl, {
+    status: 307,
+    headers: { 'Cache-Control': 'public, max-age=3600' },
+  });
+}

--- a/src/features/submit/services/upload.service.ts
+++ b/src/features/submit/services/upload.service.ts
@@ -7,8 +7,8 @@ export async function uploadImages(files: File[]): Promise<UploadResult[]> {
 
   for (const file of files) {
     const params = new URLSearchParams({
-      fileName: file.name,
       contentType: file.type,
+      type: 'preview',
     });
     const presignResponse = await fetch(
       `${process.env.NEXT_PUBLIC_API_URL}/api/images/uploads/presigned?${params}`,


### PR DESCRIPTION
## Summary

Fixed broken image display and upload introduced when the S3 image pipeline was added:

- **`/api/signed` proxy route**: Added a new Next.js API route (`src/app/api/signed/route.ts`) that accepts an S3 key and redirects to a fresh 1-hour presigned GET URL, so images can be served securely without exposing S3 credentials to the client.
- **`next.config.ts` local patterns**: Allowed the `/api/signed` endpoint to be used as an image source for Next.js Image optimization.
- **Missing `type` param on upload**: `uploadImages()` was sending `fileName` (unused by the backend) but omitting the required `type` query param, causing a Zod parse error (`expected string, received undefined`). Fixed by sending `type: 'preview'` instead.

## Linked Issues

N/A

## Type of Change

- [ ] feat: New feature
- [x] fix: Bug fix
- [ ] docs: Documentation update
- [ ] chore/refactor: Maintenance or code restructure

## Notes for Reviewers
- The `type` field in the presign schema routes uploads: `"icon"` → `icons/` folder; anything else → `preview-images/`.
