### PR TITLE
 feat: add permanent delete action for REMOVED apps in admin panel

### DIFF
--- a/src/features/admin/components/PendingAppCard.tsx
+++ b/src/features/admin/components/PendingAppCard.tsx
@@ -10,9 +10,11 @@ interface PendingAppCardProps {
   onApprove: (id: number) => void;
   onRequestChanges: (id: number) => void;
   onRemove: (id: number) => void;
+  onPermanentDelete?: (id: number) => void;
   isApproving: boolean;
   isRequestingChanges: boolean;
   isRemoving: boolean;
+  isDeleting?: boolean;
 }
 
 const STATUS_DOT: Record<AdminApplicationStatus, { label: string; color: string }> = {
@@ -29,16 +31,19 @@ export function PendingAppCard({
   onApprove,
   onRequestChanges,
   onRemove,
+  onPermanentDelete,
   isApproving,
   isRequestingChanges,
   isRemoving,
+  isDeleting = false,
 }: PendingAppCardProps) {
-  const isBusy = isApproving || isRequestingChanges || isRemoving;
+  const isBusy = isApproving || isRequestingChanges || isRemoving || isDeleting;
   const dot = STATUS_DOT[tab];
 
   const showApprove         = tab === 'PENDING' || tab === 'CHANGES_REQUESTED' || tab === 'REMOVED';
   const showRequestChanges  = tab === 'PENDING';
   const showRemove          = tab === 'APPROVED' || tab === 'PENDING' || tab === 'CHANGES_REQUESTED';
+  const showPermanentDelete = tab === 'REMOVED';
 
   return (
     <AppCard
@@ -95,6 +100,16 @@ export function PendingAppCard({
               className="w-7 h-7 flex items-center justify-center rounded-lg text-white/30 hover:text-white/60 hover:bg-white/10 transition-colors disabled:opacity-40"
             >
               {isRemoving ? <span className="text-[10px]">…</span> : <FiTrash2 className="w-3.5 h-3.5" />}
+            </button>
+          )}
+          {showPermanentDelete && (
+            <button
+              disabled={isBusy}
+              onClick={() => onPermanentDelete?.(app.id)}
+              title="Permanently Delete"
+              className="w-7 h-7 flex items-center justify-center rounded-lg text-red-400/60 hover:text-red-400 hover:bg-red-500/15 transition-colors disabled:opacity-40"
+            >
+              {isDeleting ? <span className="text-[10px]">…</span> : <FiTrash2 className="w-3.5 h-3.5" />}
             </button>
           )}
         </div>

--- a/src/features/admin/components/PermanentDeleteModal.tsx
+++ b/src/features/admin/components/PermanentDeleteModal.tsx
@@ -1,0 +1,37 @@
+import { Modal } from '@/components/atoms/Modal';
+import { Button } from '@/components/atoms/Button';
+
+interface PermanentDeleteModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  isSubmitting: boolean;
+}
+
+export function PermanentDeleteModal({ isOpen, onClose, onConfirm, isSubmitting }: PermanentDeleteModalProps) {
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="Permanently Delete Application">
+      <div className="flex flex-col gap-4">
+        <p className="text-sm text-white/70">
+          This will permanently delete the app and all associated media from S3.{' '}
+          <span className="text-red-400 font-medium">This cannot be undone.</span>
+        </p>
+
+        <div className="flex justify-end gap-3">
+          <Button variant="ghost" size="sm" onClick={onClose} disabled={isSubmitting}>
+            Cancel
+          </Button>
+          <Button
+            variant="primary"
+            size="sm"
+            onClick={onConfirm}
+            disabled={isSubmitting}
+            className="bg-red-600/70 hover:bg-red-600 border border-red-500/30 disabled:opacity-50"
+          >
+            {isSubmitting ? 'Deleting…' : 'Permanently Delete'}
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/src/features/admin/containers/ApprovalContainer.tsx
+++ b/src/features/admin/containers/ApprovalContainer.tsx
@@ -4,12 +4,14 @@ import { useState } from 'react';
 import { AnimatePresence } from 'motion/react';
 import { PendingAppCard } from '../components/PendingAppCard';
 import { RemoveModal } from '../components/RemoveModal';
+import { PermanentDeleteModal } from '../components/PermanentDeleteModal';
 import {
   useAdminApplicationsQuery,
   useApproveApplicationMutation,
   useRequestChangesMutation,
   useRemoveApplicationMutation,
   useSetApplicationUnclaimedMutation,
+  usePermanentlyDeleteApplicationMutation,
 } from '../queries/admin.queries';
 import type { RemoveModalState } from '../types/admin.types';
 import type { AdminApplicationStatus } from '../services/admin.service';
@@ -249,6 +251,7 @@ export function ApprovalContainer() {
   const approveMutation          = useApproveApplicationMutation();
   const requestChangesMutation   = useRequestChangesMutation();
   const removeMutation           = useRemoveApplicationMutation();
+  const permanentDeleteMutation  = usePermanentlyDeleteApplicationMutation();
   const updateMutation           = useUpdateApplicationMutation();
   const setUnclaimedMutation     = useSetApplicationUnclaimedMutation();
 
@@ -258,6 +261,11 @@ export function ApprovalContainer() {
     isOpen: false,
     applicationId: null,
     reason: '',
+  });
+
+  const [permanentDeleteModal, setPermanentDeleteModal] = useState<{ isOpen: boolean; applicationId: number | null }>({
+    isOpen: false,
+    applicationId: null,
   });
 
   const handleApprove = (id: number) => {
@@ -294,6 +302,22 @@ export function ApprovalContainer() {
         onError: () => addToast('Failed to remove application', 'error'),
       },
     );
+  };
+
+  const handleOpenPermanentDelete = (id: number) => {
+    setPermanentDeleteModal({ isOpen: true, applicationId: id });
+  };
+
+  const handleConfirmPermanentDelete = () => {
+    if (permanentDeleteModal.applicationId == null) return;
+    permanentDeleteMutation.mutate(permanentDeleteModal.applicationId, {
+      onSuccess: () => {
+        setPermanentDeleteModal({ isOpen: false, applicationId: null });
+        addToast('Application permanently deleted', 'success');
+        setSelectedApp(null);
+      },
+      onError: () => addToast('Failed to permanently delete application', 'error'),
+    });
   };
 
   const handleToggleUnclaimed = (id: number, unclaimed: boolean) => {
@@ -352,7 +376,22 @@ export function ApprovalContainer() {
       );
     }
     if (status === 'REMOVED') {
-      return <ReasonBanner status="REMOVED" reason={app.rejectionReason} />;
+      const isDeleting = permanentDeleteMutation.isPending && permanentDeleteMutation.variables === app.id;
+      return (
+        <div className="flex flex-col gap-2">
+          <ReasonBanner status="REMOVED" reason={app.rejectionReason} />
+          <div className="rounded-xl border border-white/8 bg-white/[0.03] p-3 flex flex-col gap-2">
+            <p className="text-[10px] font-semibold text-white/30 uppercase tracking-widest">Actions</p>
+            <button
+              disabled={isDeleting}
+              onClick={() => handleOpenPermanentDelete(app.id)}
+              className="w-full py-1.5 rounded-lg text-xs font-semibold bg-white/5 hover:bg-red-500/15 text-white/40 hover:text-red-400 border border-white/10 hover:border-red-500/20 transition-colors disabled:opacity-40 cursor-pointer disabled:cursor-not-allowed"
+            >
+              {isDeleting ? 'Deleting…' : 'Permanently Delete'}
+            </button>
+          </div>
+        </div>
+      );
     }
     if (status === 'APPROVED') {
       return (
@@ -418,9 +457,11 @@ export function ApprovalContainer() {
               onApprove={handleApprove}
               onRequestChanges={(id) => handleRequestChanges(id, '')}
               onRemove={handleOpenRemove}
+              onPermanentDelete={handleOpenPermanentDelete}
               isApproving={approveMutation.isPending && approveMutation.variables === app.id}
               isRequestingChanges={requestChangesMutation.isPending && requestChangesMutation.variables?.id === app.id}
               isRemoving={removeMutation.isPending && removeMutation.variables?.id === app.id}
+              isDeleting={permanentDeleteMutation.isPending && permanentDeleteMutation.variables === app.id}
             />
           ))}
         </div>
@@ -459,6 +500,13 @@ export function ApprovalContainer() {
         onClose={() => setRemoveModal({ isOpen: false, applicationId: null, reason: '' })}
         onConfirm={handleConfirmRemove}
         isSubmitting={removeMutation.isPending}
+      />
+
+      <PermanentDeleteModal
+        isOpen={permanentDeleteModal.isOpen}
+        onClose={() => setPermanentDeleteModal({ isOpen: false, applicationId: null })}
+        onConfirm={handleConfirmPermanentDelete}
+        isSubmitting={permanentDeleteMutation.isPending}
       />
     </div>
   );

--- a/src/features/admin/queries/admin.queries.ts
+++ b/src/features/admin/queries/admin.queries.ts
@@ -7,6 +7,7 @@ import {
   removeApplication,
   editApplication,
   setApplicationUnclaimed,
+  permanentlyDeleteApplication,
   getAdminClaimRequests,
   reviewClaimRequest,
   type AdminApplicationStatus,
@@ -121,6 +122,26 @@ export function useSetApplicationUnclaimedMutation() {
         (old) => old
           ? { ...old, data: old.data.map((a) => (a.id === id ? { ...a, unclaimed } : a)) }
           : old,
+      );
+      return { snapshots };
+    },
+    onError: (_err, _vars, context) => {
+      context?.snapshots.forEach(([key, val]) => qc.setQueryData(key, val));
+    },
+    onSettled: () => qc.invalidateQueries({ queryKey: ADMIN_KEY }),
+  });
+}
+
+export function usePermanentlyDeleteApplicationMutation() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: number) => permanentlyDeleteApplication(id),
+    onMutate: async (id) => {
+      await qc.cancelQueries({ queryKey: ADMIN_KEY });
+      const snapshots = qc.getQueriesData<ApplicationsListResponse>({ queryKey: ADMIN_KEY });
+      qc.setQueriesData<ApplicationsListResponse>(
+        { queryKey: ADMIN_KEY },
+        (old) => old ? { ...old, data: old.data.filter((a) => a.id !== id) } : old,
       );
       return { snapshots };
     },

--- a/src/features/admin/services/admin.service.ts
+++ b/src/features/admin/services/admin.service.ts
@@ -98,6 +98,17 @@ export async function editApplication(
   return response.json();
 }
 
+export async function permanentlyDeleteApplication(id: number): Promise<void> {
+  const response = await fetch(`${BASE}/admin/${id}`, {
+    method: 'DELETE',
+    credentials: 'include',
+  });
+
+  if (!response.ok) {
+    throw new Error('Failed to permanently delete application');
+  }
+}
+
 export async function setApplicationUnclaimed(
   id: number,
   unclaimed: boolean,


### PR DESCRIPTION
## Summary

Adds a "Permanently Delete" button to the admin panel's Removed tab. Clicking the button opens a `PermanentDeleteModal` confirmation dialog that warns the admin the action will destroy all S3 media and cannot be undone. On confirm, the mutation calls `DELETE /api/applications/admin/:id`, optimistically removes the app from the cached list, and invalidates admin queries on settlement. The button is only rendered when the application status is `REMOVED`.

## Linked Issues

N/A

## Type of Change

- [x] feat: New feature
- [ ] fix: Bug fix
- [ ] docs: Documentation update
- [ ] chore/refactor: Maintenance or code restructure

## Notes for Reviewers

- Button is only visible for apps with `REMOVED` status, no risk of accidentally deleting live or pending apps from the UI
- Optimistic update immediately removes the card from the list; rolls back automatically on API error
- `credentials: 'include'` is set on the fetch, admin must be logged in with a valid session cookie
- Requires the backend PR (feat: add admin permanent delete endpoint for removed applications) to be deployed first
