### PR TITLE
fix: reworked cors policy

### DIFF
--- a/scripts/set-cors.mjs
+++ b/scripts/set-cors.mjs
@@ -12,7 +12,9 @@ const s3 = new S3Client({
 
 const allowedOrigins = [
   'http://localhost:3000',
-  'https://lasallian-me.dev.app.dlsu-lscs.org' 
+  'https://lasallian-me.dev.app.dlsu-lscs.org',
+  'https://stage.pana.tools',
+  'https://pana.tools',
 ];
 
 await s3.send(
@@ -20,17 +22,8 @@ await s3.send(
     Bucket: process.env.S3_BUCKET,
     CORSConfiguration: {
       CORSRules: [
-        // Cors rule for local development
         {
-          AllowedOrigins: ['http://localhost:3000'],
-          AllowedMethods: ['PUT'],
-          AllowedHeaders: ['*'],
-          ExposeHeaders: ['ETag'],
-          MaxAgeSeconds: 3600,
-        },
-        // Cors rule for deployment
-        {
-          AllowedOrigins: ['https://lasallian-me.dev.app.dlsu-lscs.org'],
+          AllowedOrigins: allowedOrigins,
           AllowedMethods: ['PUT'],
           AllowedHeaders: ['*'],
           ExposeHeaders: ['ETag'],


### PR DESCRIPTION
## Summary

Adds `https://pana.tools` and `https://stage.pana.tools` to the S3 bucket's CORS allowed origins so that browser-initiated PUT requests (direct-to-S3 uploads via presigned URLs) succeed from the production and staging deployments. Previously, only `http://localhost:3000` and `https://lasallian-me.dev.app.dlsu-lscs.org` were whitelisted, causing all image upload attempts from pana.tools to fail at the CORS preflight stage. Also consolidates the two separate per-origin CORS rules into a single rule with all origins.

## Linked Issues

N/A

## Type of Change

- [ ] feat: New feature
- [x] fix: Bug fix
- [ ] docs: Documentation update
- [ ] chore/refactor: Maintenance or code restructure

## Notes for Reviewers
NA