### PR TITLE
feat: added photo upload size limit 5mb for icon, 10mb for previews

### DIFF
--- a/src/features/admin/components/EditModal.tsx
+++ b/src/features/admin/components/EditModal.tsx
@@ -59,6 +59,8 @@ export function EditModal({ isOpen, onClose, application, onSave, isSubmitting }
   const [iconPreviewUrl, setIconPreviewUrl] = useState<string | null>(null);
   const [isUploading, setIsUploading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [iconSizeError, setIconSizeError] = useState<string | null>(null);
+  const [previewSizeError, setPreviewSizeError] = useState<string | null>(null);
 
   const fileInputRef = useRef<HTMLInputElement>(null);
   const iconInputRef = useRef<HTMLInputElement>(null);
@@ -99,7 +101,14 @@ export function EditModal({ isOpen, onClose, application, onSave, isSubmitting }
 
   const addFiles = (incoming: File[]) => {
     const images = incoming.filter((file) => file.type.startsWith('image/'));
-    setNewPreviewFiles((prev) => [...prev, ...images].slice(0, 5));
+    const oversized = images.filter((f) => f.size > 10 * 1024 * 1024);
+    const valid = images.filter((f) => f.size <= 10 * 1024 * 1024);
+    if (oversized.length > 0) {
+      setPreviewSizeError(`${oversized.length} file(s) exceeded 10 MB and were not added.`);
+    } else {
+      setPreviewSizeError(null);
+    }
+    setNewPreviewFiles((prev) => [...prev, ...valid].slice(0, 5));
     if (fileInputRef.current) fileInputRef.current.value = '';
   };
 
@@ -123,8 +132,13 @@ export function EditModal({ isOpen, onClose, application, onSave, isSubmitting }
   const handleIconChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (file && file.type.startsWith('image/')) {
-      setIconFile(file);
-      setIconUrl('');
+      if (file.size > 5 * 1024 * 1024) {
+        setIconSizeError('Icon must be 5 MB or less.');
+      } else {
+        setIconSizeError(null);
+        setIconFile(file);
+        setIconUrl('');
+      }
     }
     if (iconInputRef.current) iconInputRef.current.value = '';
   };
@@ -297,6 +311,9 @@ export function EditModal({ isOpen, onClose, application, onSave, isSubmitting }
                 </>
               )}
             </div>
+            {iconSizeError && (
+              <p className="mt-1 text-xs text-red-400">{iconSizeError}</p>
+            )}
           </div>
 
           {/* Preview Images */}
@@ -320,8 +337,11 @@ export function EditModal({ isOpen, onClose, application, onSave, isSubmitting }
               <p className="text-sm text-white/40">
                 Drop images here or <span className="text-white/60 font-semibold">click to browse</span>
               </p>
-              <p className="text-xs text-white/25 mt-1">Up to 5 images, max 5 MB each.</p>
+              <p className="text-xs text-white/25 mt-1">Up to 5 images, max 10 MB each.</p>
             </div>
+            {previewSizeError && (
+              <p className="mt-1.5 text-xs text-red-400">{previewSizeError}</p>
+            )}
 
             {(existingPreviewImages.length > 0 || newPreviewUrls.length > 0) && (
               <div className="mt-3 grid grid-cols-3 gap-2">

--- a/src/features/apps/components/AppEditSidebar.tsx
+++ b/src/features/apps/components/AppEditSidebar.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Image from 'next/image';
-import { useRef } from 'react';
+import { useRef, useState } from 'react';
 import {
   FiUpload, FiX,
   FiGlobe, FiGithub, FiUser, FiTag, FiHash,
@@ -47,17 +47,32 @@ export function AppEditSidebar({
 }: AppEditSidebarProps) {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const iconInputRef = useRef<HTMLInputElement>(null);
+  const [iconSizeError, setIconSizeError] = useState<string | null>(null);
+  const [previewSizeError, setPreviewSizeError] = useState<string | null>(null);
 
   const addFiles = (incoming: File[]) => {
     const images = incoming.filter((f) => f.type.startsWith('image/'));
     if (!images.length) return;
-    onFormChange({ newPreviewFiles: [...formState.newPreviewFiles, ...images].slice(0, 5) });
+    const oversized = images.filter((f) => f.size > 10 * 1024 * 1024);
+    const valid = images.filter((f) => f.size <= 10 * 1024 * 1024);
+    if (oversized.length > 0) {
+      setPreviewSizeError(`${oversized.length} file(s) exceeded 10 MB and were not added.`);
+    } else {
+      setPreviewSizeError(null);
+    }
+    onFormChange({ newPreviewFiles: [...formState.newPreviewFiles, ...valid].slice(0, 5) });
     if (fileInputRef.current) fileInputRef.current.value = '';
   };
 
   const handleIconChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file?.type.startsWith('image/')) return;
+    if (file.size > 5 * 1024 * 1024) {
+      setIconSizeError('Icon must be 5 MB or less.');
+      if (iconInputRef.current) iconInputRef.current.value = '';
+      return;
+    }
+    setIconSizeError(null);
     onFormChange({ iconFile: file, iconUrl: '', removeIcon: false });
     if (iconInputRef.current) iconInputRef.current.value = '';
   };
@@ -213,6 +228,9 @@ export function AppEditSidebar({
                   Upload icon
                 </button>
               )}
+              {iconSizeError && (
+                <p className="text-xs text-red-400">{iconSizeError}</p>
+              )}
             </Field>
 
             {/* Preview images */}
@@ -234,6 +252,10 @@ export function AppEditSidebar({
                 <FiUpload className="w-3.5 h-3.5 shrink-0" />
                 Add screenshots (up to 5)
               </div>
+
+              {previewSizeError && (
+                <p className="text-xs text-red-400 mt-1">{previewSizeError}</p>
+              )}
 
               {allPreviews.length > 0 && (
                 <div className="grid grid-cols-3 gap-1.5 mt-1">

--- a/src/features/submit/components/SubmitForm.tsx
+++ b/src/features/submit/components/SubmitForm.tsx
@@ -62,6 +62,8 @@ export function SubmitForm({ onSubmit, isSubmitting, submitLabel, error, isSucce
   const [iconFile, setIconFile] = useState<File | null>(null);
   const [iconPreviewUrl, setIconPreviewUrl] = useState<string | null>(null);
   const [isDragging, setIsDragging] = useState(false);
+  const [iconSizeError, setIconSizeError] = useState<string | null>(null);
+  const [previewSizeError, setPreviewSizeError] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const iconInputRef = useRef<HTMLInputElement>(null);
 
@@ -83,7 +85,14 @@ export function SubmitForm({ onSubmit, isSubmitting, submitLabel, error, isSucce
   }, [iconFile]);
 
   const addFiles = (incoming: File[]) => {
-    setSelectedFiles((prev) => [...prev, ...incoming].slice(0, 5));
+    const oversized = incoming.filter((f) => f.size > 10 * 1024 * 1024);
+    const valid = incoming.filter((f) => f.size <= 10 * 1024 * 1024);
+    if (oversized.length > 0) {
+      setPreviewSizeError(`${oversized.length} file(s) exceeded 10 MB and were not added.`);
+    } else {
+      setPreviewSizeError(null);
+    }
+    setSelectedFiles((prev) => [...prev, ...valid].slice(0, 5));
     if (fileInputRef.current) fileInputRef.current.value = '';
   };
 
@@ -249,7 +258,14 @@ export function SubmitForm({ onSubmit, isSubmitting, submitLabel, error, isSucce
                 className="hidden"
                 onChange={(e) => {
                   const file = e.target.files?.[0];
-                  if (file) setIconFile(file);
+                  if (file) {
+                    if (file.size > 5 * 1024 * 1024) {
+                      setIconSizeError('Icon must be 5 MB or less.');
+                    } else {
+                      setIconSizeError(null);
+                      setIconFile(file);
+                    }
+                  }
                   if (iconInputRef.current) iconInputRef.current.value = '';
                 }}
               />
@@ -282,6 +298,9 @@ export function SubmitForm({ onSubmit, isSubmitting, submitLabel, error, isSucce
               )}
             </div>
             <p className="mt-1.5 text-xs text-white/30">Square image, max 5 MB</p>
+            {iconSizeError && (
+              <p className="mt-1 text-xs text-red-400">{iconSizeError}</p>
+            )}
           </div>
 
           {/* Preview Images */}
@@ -310,6 +329,10 @@ export function SubmitForm({ onSubmit, isSubmitting, submitLabel, error, isSucce
               </p>
               <p className="text-xs text-white/25 mt-1">Up to 5 images</p>
             </div>
+
+            {previewSizeError && (
+              <p className="mt-1.5 text-xs text-red-400">{previewSizeError}</p>
+            )}
 
             {previewUrls.length > 0 && (
               <div className="mt-2.5 flex flex-wrap gap-2">


### PR DESCRIPTION
# feat(web): enforce client-side file size limits on image uploads

## Summary

Added client-side file size validation to all three image upload surfaces in the web app. Previously, the UI hinted at a "max 5 MB" limit for icons but nothing was actually enforced; users could upload arbitrarily large files. Now, oversized files are rejected before the upload starts, with an inline error message displayed near the relevant input.

Limits enforced:
- **App icon**: 5 MB max
- **Preview / screenshot images**: 10 MB max per file

## Linked Issues

N/A

## Type of Change

- [x] feat: New feature
- [ ] fix: Bug fix
- [ ] docs: Documentation update
- [ ] chore/refactor: Maintenance or code restructure

## Notes for Reviewers

- Validation is **client-side only**, no backend or S3 bucket policy changes were made. A determined user could bypass it by uploading directly to the presigned URL. A follow-up could add `Content-Length-Range` enforcement via presigned POST if stronger guarantees are needed.
