### PR TITLE
feat: added confirmation delete for review

### DIFF
--- a/src/features/ratings/components/DeleteReviewModal.tsx
+++ b/src/features/ratings/components/DeleteReviewModal.tsx
@@ -1,0 +1,36 @@
+import { Modal } from '@/components/atoms/Modal';
+import { Button } from '@/components/atoms/Button';
+
+interface DeleteReviewModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  isSubmitting: boolean;
+}
+
+export function DeleteReviewModal({ isOpen, onClose, onConfirm, isSubmitting }: DeleteReviewModalProps) {
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="Delete Review">
+      <div className="flex flex-col gap-4">
+        <p className="text-sm text-white/70">
+          Are you sure you want to delete your review?{' '}
+          <span className="text-red-400 font-medium">This cannot be undone.</span>
+        </p>
+        <div className="flex justify-end gap-3">
+          <Button variant="ghost" size="sm" onClick={onClose} disabled={isSubmitting}>
+            Cancel
+          </Button>
+          <Button
+            variant="primary"
+            size="sm"
+            onClick={onConfirm}
+            disabled={isSubmitting}
+            className="bg-red-600/70 hover:bg-red-600 border border-red-500/30 disabled:opacity-50"
+          >
+            {isSubmitting ? 'Deleting…' : 'Delete Review'}
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/src/features/ratings/containers/RatingsContainer.tsx
+++ b/src/features/ratings/containers/RatingsContainer.tsx
@@ -12,6 +12,7 @@ import {
   usePatchRatingMutation,
 } from '../queries/ratings.queries';
 import type { CreateRatingPayload, Rating } from '../types/rating.types';
+import { DeleteReviewModal } from '../components/DeleteReviewModal';
 import Link from 'next/link';
 
 interface RatingsContainerProps {
@@ -367,6 +368,7 @@ export function RatingsContainer({ slug }: RatingsContainerProps) {
   const reviewsRef = useRef<HTMLDivElement>(null);
 
   const [isEditing, setIsEditing] = useState(false);
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const [dialogData, setDialogData] = useState<DialogData | null>(null);
   const [anonCache, setAnonCache] = useState<Pick<
     CreateRatingPayload,
@@ -425,11 +427,14 @@ export function RatingsContainer({ slug }: RatingsContainerProps) {
     });
   };
 
-  const handleDelete = () => {
+  const handleDelete = () => setIsDeleteModalOpen(true);
+
+  const handleConfirmDelete = () => {
     deleteMutation.mutate(undefined, {
       onSuccess: () => {
         localStorage.removeItem(anonKey);
         setAnonCache(null);
+        setIsDeleteModalOpen(false);
       },
     });
   };
@@ -454,6 +459,12 @@ export function RatingsContainer({ slug }: RatingsContainerProps) {
 
   return (
     <>
+      <DeleteReviewModal
+        isOpen={isDeleteModalOpen}
+        onClose={() => setIsDeleteModalOpen(false)}
+        onConfirm={handleConfirmDelete}
+        isSubmitting={deleteMutation.isPending}
+      />
       <div className="border-t border-white/8 py-5">
         {/* Header */}
         <div className="px-6 mb-4 flex flex-col gap-1">


### PR DESCRIPTION
# feat: add confirmation dialog before deleting a review

## Summary

Clicking the trash icon on a user's own review previously triggered an immediate DELETE request with no confirmation step, making accidental irreversible deletions possible. This change intercepts the delete action with a modal dialog that requires explicit confirmation before the mutation is fired.

A new `DeleteReviewModal` component was created in `features/ratings/components/` following the same pattern used by `PermanentDeleteModal` in the admin feature (base `Modal` atom + two-button destructive layout). `RatingsContainer` was updated to gate the mutation behind the modal: `handleDelete` now opens the modal, and a new `handleConfirmDelete` handler fires the mutation and closes the modal on success.

## Linked Issues

closes #64 

## Type of Change

- [x] feat: New feature
- [ ] fix: Bug fix
- [ ] docs: Documentation update
- [ ] chore/refactor: Maintenance or code restructure

## Notes for Reviewers

- No API, env var, or dependency changes — purely frontend.
- Two files changed: new `DeleteReviewModal.tsx` and updated `RatingsContainer.tsx`.
- The modal disables both buttons and shows "Deleting…" while the request is in-flight, preventing double-submits.
- Escape key and clicking the backdrop both cancel (inherited from the base `Modal` atom).
