### PR TITLE
Feat/image and UI updates

### DIFF
--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -2,16 +2,40 @@ import Link from 'next/link';
 
 export default function NotFound() {
   return (
-    <div className="min-h-[70vh] flex flex-col items-center justify-center bg-gray-50 p-8">
-      <div className="text-center">
-        <h1 className="text-6xl font-extrabold text-green-600 mb-2">404</h1>
-        <h2 className="text-3xl font-semibold text-gray-900 mb-4">Page Not Found</h2>
-        <p className="text-gray-600 mb-8">
+    <div className="min-h-[calc(100dvh-10rem)] flex items-center justify-center px-4">
+      <div className="glass-md rounded-2xl p-10 max-w-md w-full text-center animate-glass-enter">
+        <svg
+          className="mx-auto mb-6 text-primary-400/60"
+          width="56"
+          height="56"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <circle cx="11" cy="11" r="8" />
+          <path d="m21 21-4.35-4.35" />
+          <path d="M11 8v3m0 3v.01" />
+        </svg>
+
+        <p className="font-display text-8xl font-bold text-primary-400 leading-none mb-4">
+          404
+        </p>
+
+        <h1 className="text-2xl font-semibold text-white/90 mb-3">
+          Page Not Found
+        </h1>
+
+        <p className="text-sm text-white/55 mb-8 leading-relaxed">
           The page you&apos;re looking for doesn&apos;t exist or has been moved.
         </p>
+
         <Link
           href="/"
-          className="px-6 py-3 bg-green-600 text-white font-medium rounded-lg hover:bg-green-700 transition-colors"
+          className="inline-flex items-center justify-center font-semibold rounded-full transition-colors bg-white text-black hover:bg-white/90 px-6 py-3 text-base cursor-pointer"
         >
           Go to App Directory
         </Link>

--- a/src/features/apps/components/ResubmitConfirmModal.tsx
+++ b/src/features/apps/components/ResubmitConfirmModal.tsx
@@ -1,0 +1,41 @@
+import { Modal } from '@/components/atoms/Modal';
+import { Button } from '@/components/atoms/Button';
+import { FiAlertTriangle } from 'react-icons/fi';
+
+interface ResubmitConfirmModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  isSubmitting: boolean;
+}
+
+export function ResubmitConfirmModal({ isOpen, onClose, onConfirm, isSubmitting }: ResubmitConfirmModalProps) {
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="Save & Resubmit for Review">
+      <div className="flex flex-col gap-4">
+        <div className="flex gap-3">
+          <FiAlertTriangle className="w-5 h-5 shrink-0 mt-0.5 text-amber-400" />
+          <p className="text-sm text-white/70 leading-relaxed">
+            This app is currently <span className="text-white font-medium">approved</span> and publicly visible.
+            Saving changes will send it back for admin review and it will appear as{' '}
+            <span className="text-amber-400 font-medium">pending</span> until an admin approves it again.
+          </p>
+        </div>
+
+        <div className="flex justify-end gap-3">
+          <Button variant="ghost" size="sm" onClick={onClose} disabled={isSubmitting}>
+            Cancel
+          </Button>
+          <Button
+            variant="primary"
+            size="sm"
+            onClick={onConfirm}
+            disabled={isSubmitting}
+          >
+            {isSubmitting ? 'Saving…' : 'Save & Resubmit'}
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/src/features/apps/containers/EditApplicationContainer.tsx
+++ b/src/features/apps/containers/EditApplicationContainer.tsx
@@ -6,6 +6,7 @@ import { authClient } from '@/lib/auth-client';
 import { useUpdateApplicationMutation, useOwnApplicationBySlugQuery } from '@/features/apps/queries/apps.queries';
 import { FiAlertTriangle } from 'react-icons/fi';
 import { AppEditPreviewPanel } from '@/features/apps/components/AppEditPreviewPanel';
+import { ResubmitConfirmModal } from '@/features/apps/components/ResubmitConfirmModal';
 import { Application } from '@/features/apps/types/app.types';
 import { Skeleton } from '@/components/atoms/Skeleton';
 
@@ -16,6 +17,7 @@ export function EditApplicationContainer({ slug }: { slug: string }) {
   const { data: session, isPending: isSessionPending } = authClient.useSession();
   const { data: app, isLoading, isError } = useOwnApplicationBySlugQuery(slug);
   const updateMutation = useUpdateApplicationMutation();
+  const [pendingUpdates, setPendingUpdates] = useState<Partial<Application> | null>(null);
 
   useEffect(() => { setHasMounted(true); }, []);
 
@@ -52,13 +54,22 @@ export function EditApplicationContainer({ slug }: { slug: string }) {
   }
 
   const isChangesRequested = app.status === 'CHANGES_REQUESTED';
+  const isApproved = app.status === 'APPROVED';
 
   const handleSave = (updates: Partial<Application>) => {
+    if (isApproved) {
+      setPendingUpdates(updates);
+      return;
+    }
+    submitUpdates(updates);
+  };
+
+  const submitUpdates = (updates: Partial<Application>) => {
     updateMutation.mutate(
       { id: app.id, updates },
       {
         onSuccess: (result) => {
-          if (isChangesRequested) {
+          if (isChangesRequested || isApproved) {
             router.push('/');
           } else {
             const destination = result?.slug
@@ -69,6 +80,11 @@ export function EditApplicationContainer({ slug }: { slug: string }) {
         },
       },
     );
+  };
+
+  const handleConfirmResubmit = () => {
+    if (!pendingUpdates) return;
+    submitUpdates(pendingUpdates);
   };
 
   const changesRequestedBanner = isChangesRequested ? (
@@ -84,12 +100,20 @@ export function EditApplicationContainer({ slug }: { slug: string }) {
   ) : null;
 
   return (
-    <AppEditPreviewPanel
-      app={app}
-      onSave={handleSave}
-      isSaving={updateMutation.isPending}
-      saveError={updateMutation.isError ? updateMutation.error?.message : null}
-      sidebarTop={changesRequestedBanner}
-    />
+    <>
+      <AppEditPreviewPanel
+        app={app}
+        onSave={handleSave}
+        isSaving={updateMutation.isPending}
+        saveError={updateMutation.isError ? updateMutation.error?.message : null}
+        sidebarTop={changesRequestedBanner}
+      />
+      <ResubmitConfirmModal
+        isOpen={pendingUpdates !== null}
+        onClose={() => setPendingUpdates(null)}
+        onConfirm={handleConfirmResubmit}
+        isSubmitting={updateMutation.isPending}
+      />
+    </>
   );
 }

--- a/src/features/submit/components/SubmitForm.tsx
+++ b/src/features/submit/components/SubmitForm.tsx
@@ -271,18 +271,20 @@ export function SubmitForm({ onSubmit, isSubmitting, submitLabel, error, isSucce
               />
               {iconPreviewUrl ? (
                 <div className="flex items-center gap-3">
-                  <div className="relative w-14 h-14 shrink-0 rounded-xl overflow-hidden border border-white/10">
-                    <Image
-                      fill
-                      unoptimized
-                      src={iconPreviewUrl}
-                      alt="Icon preview"
-                      className="object-cover"
-                    />
+                  <div className="relative w-14 h-14 shrink-0">
+                    <div className="relative w-14 h-14 rounded-xl overflow-hidden border border-white/10">
+                      <Image
+                        fill
+                        unoptimized
+                        src={iconPreviewUrl}
+                        alt="Icon preview"
+                        className="object-cover"
+                      />
+                    </div>
                     <button
                       type="button"
                       onClick={(e) => { e.stopPropagation(); setIconFile(null); }}
-                      className="absolute -top-1.5 -right-1.5 w-5 h-5 bg-red-500 hover:bg-red-400 text-white rounded-full flex items-center justify-center cursor-pointer shadow-sm"
+                      className="absolute -top-2 -right-2 w-5 h-5 bg-red-500 hover:bg-red-400 text-white rounded-full flex items-center justify-center cursor-pointer shadow-sm z-10"
                       aria-label="Remove icon"
                     >
                       <FiX className="w-3 h-3" strokeWidth={3} />
@@ -323,39 +325,46 @@ export function SubmitForm({ onSubmit, isSubmitting, submitLabel, error, isSucce
                 className="hidden"
                 onChange={handleFileChange}
               />
-              <FiUpload className="w-5 h-5 text-white/30 mb-2" />
-              <p className="text-sm text-white/40">
-                Drop or <span className="text-white/60 font-semibold">browse</span>
-              </p>
-              <p className="text-xs text-white/25 mt-1">Up to 5 images</p>
+              {previewUrls.length > 0 ? (
+                <>
+                  <div className="flex flex-wrap gap-4 justify-center pt-2">
+                    {previewUrls.map((previewUrl, i) => (
+                      <div key={i} className="relative w-14 h-14 shrink-0">
+                        <div className="relative w-14 h-14 rounded-lg overflow-hidden border border-white/10">
+                          <Image
+                            fill
+                            unoptimized
+                            src={previewUrl}
+                            alt={selectedFiles[i]?.name ?? `Preview ${i + 1}`}
+                            className="object-cover"
+                          />
+                        </div>
+                        <button
+                          type="button"
+                          onClick={(e) => { e.stopPropagation(); removeFile(i); }}
+                          className="absolute -top-2 -right-2 w-5 h-5 bg-red-500 hover:bg-red-400 text-white rounded-full flex items-center justify-center cursor-pointer shadow-sm z-10"
+                          aria-label="Remove image"
+                        >
+                          <FiX className="w-3 h-3" strokeWidth={3} />
+                        </button>
+                      </div>
+                    ))}
+                  </div>
+                  <p className="text-xs text-white/25 mt-3">Up to 5 images</p>
+                </>
+              ) : (
+                <>
+                  <FiUpload className="w-5 h-5 text-white/30 mb-2" />
+                  <p className="text-sm text-white/40">
+                    Drop or <span className="text-white/60 font-semibold">browse</span>
+                  </p>
+                  <p className="text-xs text-white/25 mt-1">Up to 5 images</p>
+                </>
+              )}
             </div>
 
             {previewSizeError && (
               <p className="mt-1.5 text-xs text-red-400">{previewSizeError}</p>
-            )}
-
-            {previewUrls.length > 0 && (
-              <div className="mt-2.5 flex flex-wrap gap-2">
-                {previewUrls.map((previewUrl, i) => (
-                  <div key={i} className="relative w-14 h-14 shrink-0 rounded-lg overflow-hidden border border-white/10">
-                    <Image
-                      fill
-                      unoptimized
-                      src={previewUrl}
-                      alt={selectedFiles[i]?.name ?? `Preview ${i + 1}`}
-                      className="object-cover"
-                    />
-                    <button
-                      type="button"
-                      onClick={(e) => { e.stopPropagation(); removeFile(i); }}
-                      className="absolute -top-1.5 -right-1.5 w-5 h-5 bg-red-500 hover:bg-red-400 text-white rounded-full flex items-center justify-center cursor-pointer shadow-sm"
-                      aria-label="Remove image"
-                    >
-                      <FiX className="w-3 h-3" strokeWidth={3} />
-                    </button>
-                  </div>
-                ))}
-              </div>
             )}
           </div>
         </div>


### PR DESCRIPTION
# fix(submit): fix image preview placement and X button clipping in upload fields

## Summary

This branch bundles several UX improvements and bug fixes across the submit, edit, and admin panels:

- **Preview image layout**: uploaded preview images now render _inside_ the dashed drop-zone rectangle instead of below it, matching the behaviour of the app icon upload field. The upload prompt is restored when no files are selected.
- **X button clipping**: the remove button on both the app icon and preview image thumbnails was being clipped by the `overflow-hidden` container. Fixed by splitting the single `relative overflow-hidden` div into an outer `relative` anchor (for the button) and an inner `relative overflow-hidden` div (for the image clip/rounding), so the X badge renders freely above the corner.
- **Resubmit confirmation**: introduced a `ResubmitConfirmModal` in the edit flow warning authors that resubmitting sets app status back to `pending`.
- **404 page restyled**: updated `not-found.tsx` to match the app's dark theme.
- **Photo Deletion from S3 after successful path**: after image has been replaced by an approved edit, previous photos are deleted from s3

## Linked Issues

N/A

## Type of Change

- [x] feat: New feature
- [x] fix: Bug fix
- [ ] docs: Documentation update
- [ ] chore/refactor: Maintenance or code restructure

## Notes for Reviewers